### PR TITLE
fix: First name replacement

### DIFF
--- a/tRP3_RPNameInQuests/tRP3_RPNameInQuests.lua
+++ b/tRP3_RPNameInQuests/tRP3_RPNameInQuests.lua
@@ -337,7 +337,7 @@ local function TRP3RPNameInQuests_Init()
 			
 			else
 			
-				if (textToRename and not(string.find(textToRename, thisTRP3CharName))) then
+				if (textToRename and not(string.find(textToRename, thisTRP3CharName  .. "%A"))) then
 					textToRename = textToRename:gsub(TRP3_RPNameInQuests_NameToChange, thisTRP3CharName)
 				end
 


### PR DESCRIPTION
I'm in the habit of naming my characters beginning with the IC first name. I noticed that if I tried to replace my name with only the first name, no replacements were made.

This fix should ensure that the name is properly replaced even in these cases.

Steps to reproduce:
1. Create a character or use an existing one, say it's name is "TestyMcTest".
2. Set the TRP first name to "Testy"
3. Configure Quest RP names to use first name only.
4. Verify that for example quest texts is properly changed to use only the first name and not the full OOC character name.